### PR TITLE
Support for SQLite, MySQL, Postgres and Django up to 2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,9 @@ ENV/
 # Rope project settings
 .ropeproject
 
+# JetBrains project settings
+.idea
+
 # mkdocs documentation
 /site
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,49 @@ language: python
 # List the versions of Python you'd like to test against
 services:
   - postgresql
+  - mysql
 env:
   global:
     - DJANGO_SETTINGS_MODULE=tests.settings
   matrix:
-    - DJANGO_VERSION=1.8.19
-    - DJANGO_VERSION=1.9.13
-    - DJANGO_VERSION=1.10.8
-    - DJANGO_VERSION=1.11.18
+    - DJANGO_VERSION=1.8.19 DB=mysql
+    - DJANGO_VERSION=1.8.19 DB=postgres
+    - DJANGO_VERSION=1.8.19 DB=sqlite
+    - DJANGO_VERSION=1.9.13 DB=mysql
+    - DJANGO_VERSION=1.9.13 DB=postgres
+    - DJANGO_VERSION=1.9.13 DB=sqlite
+    - DJANGO_VERSION=1.10.8 DB=mysql
+    - DJANGO_VERSION=1.10.8 DB=postgres
+    - DJANGO_VERSION=1.10.8 DB=sqlite
+    - DJANGO_VERSION=1.11.18 DB=mysql
+    - DJANGO_VERSION=1.11.18 DB=postgres
+    - DJANGO_VERSION=1.11.18 DB=sqlite
+    - DJANGO_VERSION=2.0.10 DB=mysql
+    - DJANGO_VERSION=2.0.10 DB=postgres
+    - DJANGO_VERSION=2.0.10 DB=sqlite
+    - DJANGO_VERSION=2.1.5 DB=mysql
+    - DJANGO_VERSION=2.1.5 DB=postgres
+    - DJANGO_VERSION=2.1.5 DB=sqlite
+matrix:
+  exclude:
+     - python: "2.7"
+       env: DJANGO_VERSION=2.0.10 DB=mysql
+     - python: "2.7"
+       env: DJANGO_VERSION=2.0.10 DB=sqlite
+     - python: "2.7"
+       env: DJANGO_VERSION=2.0.10 DB=postgres
+     - python: "2.7"
+       env: DJANGO_VERSION=2.1.5 DB=mysql
+     - python: "2.7"
+       env: DJANGO_VERSION=2.1.5 DB=sqlite
+     - python: "2.7"
+       env: DJANGO_VERSION=2.1.5 DB=postgres
+     - python: "3.4"
+       env: DJANGO_VERSION=2.1.5 DB=mysql
+     - python: "3.4"
+       env: DJANGO_VERSION=2.1.5 DB=sqlite
+     - python: "3.4"
+       env: DJANGO_VERSION=2.1.5 DB=postgres
 python:
   - "2.7"
   - "3.4"
@@ -21,14 +56,14 @@ python:
   - "3.6"
 # Tell it the things it will need to install when it boots
 install:
- - pip install -q pytz coveralls flake8 psycopg2
- - pip install -q "Django==$DJANGO_VERSION"
- - pip install -e .
+  - pip install -q pytz coveralls flake8 psycopg2 mysqlclient
+  - pip install -q "Django==$DJANGO_VERSION"
+  - pip install -e .
 # Tell Travis how to run the test script itself
 before_script:
-  - psql -c 'create database naivedatetimefield;' -U postgres
+  - mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql
 script:
   - flake8 naivedatetimefield/
   - coverage run --parallel-mode --source=naivedatetimefield runtests.py
   - coverage combine
-after_success: coveralls
+# after_success: coveralls

--- a/naivedatetimefield/__init__.py
+++ b/naivedatetimefield/__init__.py
@@ -1,31 +1,35 @@
 import datetime
+import sys
+import warnings
 
-from django import forms
+import django
+import pytz
 from django.core import exceptions, checks
-
-from django.db import models
-
+from django.db.models import DateTimeField
 from django.utils import timezone
 from django.utils.dateparse import parse_date, parse_datetime
 from django.utils.translation import gettext_lazy as _
 
+if django.VERSION >= (1, 11):
+    from django.db.models.functions.datetime import TruncBase, Extract, ExtractYear
+    from django.db.models.lookups import Exact, GreaterThan, GreaterThanOrEqual, \
+        LessThan, LessThanOrEqual
 
-class NaiveDateTimeField(models.DateField):
+
+class NaiveDateTimeField(DateTimeField):
     description = _("Naive Date (with time)")
 
+    default_error_messages = {
+        'tzaware': _("TZ-aware datetimes cannot be coerced to naive datetimes"),
+    }
+
     def get_internal_type(self):
-        return "NaiveDateTime"
+        return "DateTimeField"
 
     def db_type(self, connection):
-        if connection.settings_dict["ENGINE"] in [
-            "django_prometheus.db.backends.postgresql",
-            "django_prometheus.db.backends.postgresql_psycopg2",
-            "django.db.backends.postgresql",
-            "django.db.backends.postgresql_psycopg2",
-        ]:
+        if connection.vendor == "postgresql":
             return "timestamp without time zone"
-
-        raise NotImplementedError("Only postgresql is supported at this time.")
+        return super(NaiveDateTimeField, self).db_type(connection)
 
     def _check_fix_default_value(self):
         """
@@ -81,13 +85,17 @@ class NaiveDateTimeField(models.DateField):
         if value is None:
             return value
         if isinstance(value, datetime.datetime):
-            return value.replace(tzinfo=None)
+            if timezone.is_aware(value):
+                raise exceptions.ValidationError(self.error_messages['tzaware'])
+            return value
         if isinstance(value, datetime.date):
             return datetime.datetime(value.year, value.month, value.day)
 
         try:
             parsed = parse_datetime(value)
             if parsed is not None:
+                if timezone.is_aware(parsed):
+                    raise exceptions.ValidationError(self.error_messages['tzaware'])
                 return parsed
         except ValueError:
             raise exceptions.ValidationError(
@@ -112,104 +120,91 @@ class NaiveDateTimeField(models.DateField):
         )
 
     def get_prep_value(self, value):
-        """
-        Ensure we have a naive datetime ready for insertion
-        """
-        value = super(NaiveDateTimeField, self).get_prep_value(value)
-        value = self.to_python(value)
+        return super(DateTimeField, self).get_prep_value(value)
 
-        if value is not None and timezone.is_aware(value):
-            # We were given an aware datetime, strip off tzinfo
-            value = value.replace(tzinfo=None)
-
-        return value
-
-    def get_db_prep_value(self, value, connection, prepared=False):
-        if not prepared:
-            value = self.get_prep_value(value)
-
-        if value is None:
-            return None
-
-        if hasattr(value, "resolve_expression"):
+    def from_db_value(self, value, expression, connection, context):
+        is_truncbase = django.VERSION >= (1, 11) and isinstance(expression, TruncBase)
+        if is_truncbase and not isinstance(expression, NaiveAsSQLMixin):
+            raise TypeError(
+                "Django's %s cannot be used with a NaiveDateTimeField"
+                % expression.__class__.__name__
+            )
+        if connection.vendor == "postgresql":
+            if is_truncbase:
+                return timezone.make_naive(value, pytz.utc)
             return value
-
-        if connection.settings_dict["ENGINE"] == "django.db.backends.mysql":
-            return str(value)
-
-        elif connection.settings_dict["ENGINE"] == "django.db.backends.sqlite3":
-            return str(value)
-
-        elif connection.settings_dict["ENGINE"] == "django.db.backends.oracle":
-            from django.db.backends.oracle.utils import Oracle_datetime
-
-            return Oracle_datetime.from_datetime(value)
-
+        if timezone.is_aware(value):
+            if django.VERSION < (1, 9):
+                return timezone.make_naive(value, pytz.utc)
+            return timezone.make_naive(value, connection.timezone)
         return value
 
     def pre_save(self, model_instance, add):
         if self.auto_now or (self.auto_now_add and add):
-            value = timezone.now().replace(tzinfo=None)
+            value = timezone.make_naive(timezone.now())
             setattr(model_instance, self.attname, value)
             return value
         else:
             return super(NaiveDateTimeField, self).pre_save(model_instance, add)
 
-    def value_to_string(self, obj):
-        val = self.value_from_object(obj)
-        return "" if val is None else val.isoformat()
 
-    def formfield(self, **kwargs):
-        defaults = {"form_class": forms.DateTimeField}
-        defaults.update(kwargs)
-        return super(NaiveDateTimeField, self).formfield(**defaults)
+class NaiveTimezoneMixin(object):
+    def get_tzname(self):
+        if isinstance(self.output_field, NaiveDateTimeField):
+            if self.tzinfo is not None:
+                warnings.warn(
+                    "tzinfo argument provided when truncating a NaiveDateTimeField. "
+                    "This argument will have no effect."
+                )
+            return 'UTC'
+        return super(NaiveTimezoneMixin, self).get_tzname()
 
 
-# try to register our field for the __time and __date lookups
-try:
-    from django.db.models import TimeField
-    from django.db.models.functions.datetime import TruncBase
+class NaiveConvertValueMixin(object):
+    def convert_value(self, value, *args, **kwargs):
+        if isinstance(self.output_field, NaiveDateTimeField):
+            return value
+        return super(NaiveConvertValueMixin, self).convert_value(value, *args, **kwargs)
 
-    class TruncTimeNaive(TruncBase):
-        kind = "time"
-        lookup_name = "time"
-        output_field = TimeField()
 
-        def as_sql(self, compiler, connection):
-            # Cast to date rather than truncate to date.
-            lhs, lhs_params = compiler.compile(self.lhs)
+class NaiveAsSQLMixin(object):
+    def as_sql(self, compiler, connection):
+        if isinstance(self.lhs.output_field, NaiveDateTimeField):
+            with timezone.override(pytz.utc):
+                return super(NaiveAsSQLMixin, self).as_sql(compiler, connection)
+        return super(NaiveAsSQLMixin, self).as_sql(compiler, connection)
 
-            # this is a postgresql only compatible cast, replacing
-            # a call to connection.ops.datetime_cast_time_sql that
-            # wouldn't work with None tzinfo
-            sql = "(%s)::time" % lhs
 
-            return sql, lhs_params
+_monkeypatching = False
 
-    NaiveDateTimeField.register_lookup(TruncTimeNaive)
-except ImportError:
-    pass
 
-try:
-    from django.db.models import DateField
-    from django.db.models.functions.datetime import TruncBase
+if django.VERSION >= (1, 11):
+    _this_module = sys.modules[__name__]
+    _db_functions = sys.modules['django.db.models.functions']
+    _lookups = set(DateTimeField.get_lookups().values())
+    _patch_classes = [
+        (Extract, [NaiveAsSQLMixin, NaiveTimezoneMixin]),
+        (TruncBase, [NaiveAsSQLMixin, NaiveTimezoneMixin, NaiveConvertValueMixin]),
+    ]
+    for original, mixins in _patch_classes:
+        for cls in original.__subclasses__():
 
-    class TruncDateNaive(TruncBase):
-        kind = "date"
-        lookup_name = "date"
-        output_field = DateField()
+            bases = tuple(mixins) + (cls,)
+            naive_cls = type(cls.__name__, bases, {})
 
-        def as_sql(self, compiler, connection):
-            # Cast to date rather than truncate to date.
-            lhs, lhs_params = compiler.compile(self.lhs)
+            if _monkeypatching:
+                setattr(_db_functions, cls.__name__, naive_cls)
 
-            # this is a postgresql only compatible cast, replacing
-            # a call to connection.ops.datetime_cast_date_sql that
-            # wouldn't work with None tzinfo
-            sql = "(%s)::date" % lhs
+            if cls in _lookups:
+                NaiveDateTimeField.register_lookup(naive_cls)
 
-            return sql, lhs_params
+                # Year lookups don't need special handling with naive fields
+                if cls is ExtractYear:
+                    naive_cls.register_lookup(Exact)
+                    naive_cls.register_lookup(GreaterThan)
+                    naive_cls.register_lookup(GreaterThanOrEqual)
+                    naive_cls.register_lookup(LessThan)
+                    naive_cls.register_lookup(LessThanOrEqual)
 
-    NaiveDateTimeField.register_lookup(TruncDateNaive)
-except ImportError:
-    pass
+            # Add an attribute to this module so these functions can be imported
+            setattr(_this_module, cls.__name__, naive_cls)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -26,15 +26,28 @@ MIDDLEWARE_CLASSES = (
 
 MIDDLEWARE = MIDDLEWARE_CLASSES
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+AVAILABLE_DATABASES = {
+    "sqlite": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    },
+    "postgres": {
+        "ENGINE": "django.db.backends.postgresql_psycopg2",
         "NAME": os.environ.get("DJANGO_DATABASE_NAME_POSTGRES", "naivedatetimefield"),
         "USER": os.environ.get("DJANGO_DATABASE_USER_POSTGRES", 'postgres'),
         "PASSWORD": os.environ.get("DJANGO_DATABASE_PASSWORD_POSTGRES", ""),
         "HOST": os.environ.get("DJANGO_DATABASE_HOST_POSTGRES", ""),
-    }
+    },
+    "mysql": {
+        "ENGINE": "django.db.backends.mysql",
+        "NAME": os.environ.get("DJANGO_DATABASE_NAME_MYSQL", "naivedatetimefield"),
+        "USER": os.environ.get("DJANGO_DATABASE_USER_MYSQL", 'root'),
+        "PASSWORD": os.environ.get("DJANGO_DATABASE_PASSWORD_MYSQL", ""),
+        "HOST": os.environ.get("DJANGO_DATABASE_HOST_MYSQL", ""),
+    },
 }
+
+DATABASES = {"default": AVAILABLE_DATABASES[os.environ.get("DB", "postgres")]}
 
 CACHES = {
     'default': {
@@ -68,3 +81,29 @@ TEMPLATES = [
         },
     },
 ]
+
+LOGGING = {
+    'disable_existing_loggers': False,
+    'version': 1,
+    'handlers': {
+        'console': {
+            # logging handler that outputs log messages to terminal
+            'class': 'logging.StreamHandler',
+            'level': 'DEBUG', # message level to be written to console
+        },
+    },
+    'loggers': {
+        '': {
+            # this sets root level logger to log debug and higher level
+            # logs to console. All other loggers inherit settings from
+            # root level logger.
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False, # this tells logger to send logging message
+                                # to its parent (will send if set to True)
+        },
+        'django.db': {
+            # django also has database level logging
+        },
+    },
+}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,12 +1,15 @@
 import datetime
+from unittest import skipIf
+
+import django
 import pytz
-
-from django.test import TestCase
-
-from django.db.models import F
+from django import db
 from django.contrib.auth.models import User
+from django.db.models import functions
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
+import naivedatetimefield
 from .models import (
     NaiveDateTimeTestModel,
     NaiveDateTimeAutoNowAddModel,
@@ -37,7 +40,42 @@ class NaiveDateTimeFieldTestCase(TestCase):
         self.assertTrue(timezone.is_aware(obj.aware))
         self.assertTrue(timezone.is_naive(obj.naive))
 
-    def xtest_time_lookup(self):
+    def test_timezones_ignored(self):
+
+        naive = datetime.datetime(2018, 4, 1, 18, 0)
+        o1 = NaiveDateTimeTestModel.objects.create(
+            naive=naive,
+            aware=timezone.make_aware(naive),
+        )
+
+        with timezone.override('Australia/Melbourne'):
+            o2 = NaiveDateTimeTestModel.objects.create(
+                naive=naive,
+                aware=timezone.make_aware(naive),
+            )
+            o1.refresh_from_db()
+            o2.refresh_from_db()
+
+        self.assertNotEqual(o1.aware, o2.aware)
+        self.assertEqual(o1.naive, naive)
+        self.assertEqual(o2.naive, naive)
+
+        with timezone.override('Australia/Adelaide'):
+            o1.refresh_from_db()
+            o2.refresh_from_db()
+            self.assertNotEqual(o1.aware, o2.aware)
+            self.assertEqual(o1.naive, naive)
+            self.assertEqual(o2.naive, naive)
+
+        with override_settings(USE_TZ=False):
+            o1.refresh_from_db()
+            o2.refresh_from_db()
+            self.assertNotEqual(o1.aware, o2.aware)
+            self.assertEqual(o1.naive, naive)
+            self.assertEqual(o2.naive, naive)
+
+    @skipIf(django.VERSION < (1, 11), "date transforms and lookups unavailable before Django 1.11")
+    def test_time_lookup(self):
         """
         This should test that __time lookups work properly on naive datetime fields
         """
@@ -50,22 +88,182 @@ class NaiveDateTimeFieldTestCase(TestCase):
 
         o.refresh_from_db()
 
-        results = NaiveDateTimeTestModel.objects.annotate(
-            hour=F("naive__time__hour")
-        ).filter(naive__time__hour__gte=1)
+        results = NaiveDateTimeTestModel.objects.filter(naive__time__hour__gte=1)
 
-        for ndt in NaiveDateTimeTestModel.objects.all():
-            print(ndt.id, ndt.naive)
+        self.assertEqual(results.count(), 1)
 
-        print(results, results.query)
-
-        self.assertTrue(results == 1)
-
-    def xtest_date_lookup(self):
+    @skipIf(django.VERSION < (1, 11), "date transforms and lookups unavailable before Django 1.11")
+    def test_date_trunc(self):
         """
-        This should test that __date lookups work properly on naive datetime fields
+        Test that date truncating works regardless of active timezone.
         """
-        pass
+        timezone.activate("Australia/Adelaide")
+        n = datetime.datetime(2017, 12, 31, 20, 10, 30, 123456)
+        a = timezone.make_aware(n)
+        o = NaiveDateTimeTestModel.objects.create(aware=a, naive=n)
+        o.refresh_from_db()
+
+        def query_truncations(module):
+            return NaiveDateTimeTestModel.objects.annotate(
+                year=getattr(module, 'TruncYear')("naive"),
+                mon=getattr(module, 'TruncMonth')("naive"),
+                day=getattr(module, 'TruncDay')("naive"),
+                hour=getattr(module, 'TruncHour')("naive"),
+                min=getattr(module, 'TruncMinute')("naive"),
+                sec=getattr(module, 'TruncSecond')("naive"),
+                date=getattr(module, 'TruncDate')("naive"),
+                time=getattr(module, 'TruncTime')("naive"),
+            ).all()[0]
+
+        self.assertEqual(NaiveDateTimeTestModel.objects.count(), 1)
+
+        r = query_truncations(naivedatetimefield)
+        self.assertEqual(
+            [r.year, r.mon, r.day, r.hour, r.min, r.sec, r.date, r.time],
+            [
+                datetime.datetime(2017, 1, 1),
+                datetime.datetime(2017, 12, 1),
+                datetime.datetime(2017, 12, 31),
+                datetime.datetime(2017, 12, 31, 20),
+                datetime.datetime(2017, 12, 31, 20, 10),
+                datetime.datetime(2017, 12, 31, 20, 10, 30),
+                datetime.date(2017, 12, 31),
+                datetime.time(20, 10, 30, 123456),
+            ]
+        )
+
+        with self.assertRaisesRegex(TypeError, r"Django's \w+ cannot be used with a NaiveDateTimeField"):
+            query_truncations(functions)
+
+    @skipIf(django.VERSION < (1, 11), "date transforms and lookups unavailable before Django 1.11")
+    def test_date_transforms(self):
+        """
+        Test that date transforms work regardless of active timezone.
+        """
+        timezone.activate('utc')
+
+        # Create some borderline datetimes, hard-coded for easier visualisation/verification
+        # >>> dt = datetime.datetime(2017, 1, 1, 10, 30)
+        # >>> for i in range(12): repr(dt + timedelta(days=121*i, hours=13*i, minutes=4*i, seconds=i))
+        datetimes = [
+            datetime.datetime(2017,  1,  1, 10, 30,  0),
+            datetime.datetime(2017,  5,  2, 23, 34,  1),
+            datetime.datetime(2017,  9,  1, 12, 38,  2),
+            datetime.datetime(2018,  1,  1,  1, 42,  3),
+            datetime.datetime(2018,  5,  2, 14, 46,  4),
+            datetime.datetime(2018,  9,  1,  3, 50,  5),
+            datetime.datetime(2018, 12, 31, 16, 54,  6),
+            datetime.datetime(2019,  5,  2,  5, 58,  7),
+            datetime.datetime(2019,  8, 31, 19,  2,  8),
+            datetime.datetime(2019, 12, 31,  8,  6,  9),
+            datetime.datetime(2020,  4, 30, 21, 10, 10),
+            datetime.datetime(2020,  8, 30, 10, 14, 11),
+        ]
+
+        NaiveDateTimeTestModel.objects.bulk_create(
+            NaiveDateTimeTestModel(aware=timezone.make_aware(dt), naive=dt)
+            for dt in datetimes
+        )
+
+        def count_filter(**kwargs):
+            return NaiveDateTimeTestModel.objects.filter(**kwargs).count()
+
+        def test_in_timezone(tz):
+            with timezone.override(tz):
+                self.assertEqual(count_filter(naive__year__lt=2018), 3)
+                self.assertEqual(count_filter(naive__year__lte=2018), 7)
+                self.assertEqual(count_filter(naive__year__gt=2018), 5)
+                self.assertEqual(count_filter(naive__year__gte=2018), 9)
+                self.assertEqual(count_filter(naive__year=2018), 4)
+
+                self.assertEqual(count_filter(naive__month__lt=5), 3)
+                self.assertEqual(count_filter(naive__month__lte=5), 6)
+                self.assertEqual(count_filter(naive__month__gt=5), 6)
+                self.assertEqual(count_filter(naive__month__gte=5), 9)
+                self.assertEqual(count_filter(naive__month=5), 3)
+
+                self.assertEqual(count_filter(naive__day__lt=2), 4)
+                self.assertEqual(count_filter(naive__day__lte=2), 7)
+                self.assertEqual(count_filter(naive__day__gt=2), 5)
+                self.assertEqual(count_filter(naive__day__gte=2), 8)
+                self.assertEqual(count_filter(naive__day=2), 3)
+
+                self.assertEqual(count_filter(naive__hour__lt=12), 6)
+                self.assertEqual(count_filter(naive__hour__lte=12), 7)
+                self.assertEqual(count_filter(naive__hour__gt=12), 5)
+                self.assertEqual(count_filter(naive__hour__gte=12), 6)
+                self.assertEqual(count_filter(naive__hour=12), 1)
+
+                self.assertEqual(count_filter(naive__minute__lt=30), 4)
+                self.assertEqual(count_filter(naive__minute__lte=30), 5)
+                self.assertEqual(count_filter(naive__minute__gt=30), 7)
+                self.assertEqual(count_filter(naive__minute__gte=30), 8)
+                self.assertEqual(count_filter(naive__minute=30), 1)
+
+                self.assertEqual(count_filter(naive__second__lt=6), 6)
+                self.assertEqual(count_filter(naive__second__lte=6), 7)
+                self.assertEqual(count_filter(naive__second__gt=6), 5)
+                self.assertEqual(count_filter(naive__second__gte=6), 6)
+                self.assertEqual(count_filter(naive__second=6), 1)
+
+                self.assertEqual(count_filter(naive__week__lt=30), 7)
+                self.assertEqual(count_filter(naive__week__lte=30), 7)
+                self.assertEqual(count_filter(naive__week__gt=30), 5)
+                self.assertEqual(count_filter(naive__week__gte=30), 5)
+                self.assertEqual(count_filter(naive__week=30), 0)
+
+                self.assertEqual(count_filter(naive__week_day__lt=4), 6)
+                self.assertEqual(count_filter(naive__week_day__lte=4), 7)
+                self.assertEqual(count_filter(naive__week_day__gt=4), 5)
+                self.assertEqual(count_filter(naive__week_day__gte=4), 6)
+                self.assertEqual(count_filter(naive__week_day=4), 1)
+
+                self.assertEqual(count_filter(naive__date__lt=datetime.date(2018, 12, 31)), 6)
+                self.assertEqual(count_filter(naive__date__lte=datetime.date(2018, 12, 31)), 7)
+                self.assertEqual(count_filter(naive__date__gt=datetime.date(2018, 12, 31)), 5)
+                self.assertEqual(count_filter(naive__date__gte=datetime.date(2018, 12, 31)), 6)
+                self.assertEqual(count_filter(naive__date=datetime.date(2018, 12, 31)), 1)
+
+                if db.connection.vendor != 'mysql':  # known bug in Django's mysql date handling
+                    self.assertEqual(count_filter(naive__time__lt=datetime.time(10, 30, 0)), 5)
+                    self.assertEqual(count_filter(naive__time__lte=datetime.time(10, 30, 0)), 6)
+                    self.assertEqual(count_filter(naive__time__gt=datetime.time(10, 30, 0)), 6)
+                    self.assertEqual(count_filter(naive__time__gte=datetime.time(10, 30, 0)), 7)
+                    self.assertEqual(count_filter(naive__time=datetime.time(10, 30, 0)), 1)
+
+        # Test in some out-there timezones
+        test_in_timezone('utc')
+        test_in_timezone('Pacific/Chatham')  # +12:45/+13:45
+        test_in_timezone('Pacific/Marquesas')  # -09:30
+
+    @skipIf(django.VERSION < (1, 11), "date transforms and lookups unavailable before Django 1.11")
+    def test_date_extract_annotations(self):
+        """
+        Test that date truncating works regardless of active timezone.
+        """
+        timezone.activate("Australia/Adelaide")
+        n = datetime.datetime(2017, 12, 31, 20, 10, 30, 123456)
+        a = timezone.make_aware(n)
+        o = NaiveDateTimeTestModel.objects.create(aware=a, naive=n)
+        o.refresh_from_db()
+
+        def query_transforms(module):
+            return NaiveDateTimeTestModel.objects.annotate(
+                year=getattr(module, 'ExtractYear')("naive"),
+                mon=getattr(module, 'ExtractMonth')("naive"),
+                day=getattr(module, 'ExtractDay')("naive"),
+                hour=getattr(module, 'ExtractHour')("naive"),
+                min=getattr(module, 'ExtractMinute')("naive"),
+                sec=getattr(module, 'ExtractSecond')("naive"),
+                week=getattr(module, 'ExtractWeek')("naive"),
+                dow=getattr(module, 'ExtractWeekDay')("naive"),
+            )[0]
+
+        r = query_transforms(naivedatetimefield)
+        self.assertEqual(
+            [r.year, r.mon, r.day, r.hour, r.min, r.sec, r.week, r.dow],
+            [2017, 12, 31, 20, 10, 30, 52, 1],
+        )
 
     def test_add_los_angeles_local_timestamp(self):
         """


### PR DESCRIPTION
Hi Camron,

This is a fairly big refactor in places, but brings support for all Django versions from 1.8 up, and adds transforms and lookups that work with the NaiveDateTimeField.

I don't think there's any way to make the existing transforms and lookups work 100% of the time without monkeypatching, but I think this is a pretty good case where that would be worth doing.

Tests are still somewhat incomplete.

What's your stance on Django support? Are you open to dropping support for any of the unsupported versions?

Cheers
Alex