### PR TITLE
Correctly handle None being returned from the database backend

### DIFF
--- a/naivedatetimefield/__init__.py
+++ b/naivedatetimefield/__init__.py
@@ -135,16 +135,16 @@ class NaiveDateTimeField(DateTimeField):
     def get_prep_value(self, value):
         return super(DateTimeField, self).get_prep_value(value)
 
-    def get_db_prep_value(self, value, connection, prepared=False):
-        return super().get_db_prep_value(value, connection, prepared)
+    def from_db_value(self, value, expr, connection):
+        if value is None:
+            return None
 
-    def from_db_value(self, value, expression, connection):
-        is_truncbase = isinstance(expression, TruncBase)
-        if is_truncbase and not isinstance(expression, NaiveAsSQLMixin):
+        if isinstance(expr, TruncBase) and not isinstance(expr, NaiveAsSQLMixin):
             raise TypeError(
                 "Django's %s cannot be used with a NaiveDateTimeField"
-                % expression.__class__.__name__
+                % expr.__class__.__name__
             )
+
         if timezone.is_aware(value):
             return timezone.make_naive(value, _conn_tz(connection))
         return value

--- a/tests/models.py
+++ b/tests/models.py
@@ -28,3 +28,7 @@ class NaiveDateTimeAutoNowModel(models.Model):
     naive = NaiveDateTimeField(
         auto_now=True,
     )
+
+
+class NullableNaiveDateTimeModel(models.Model):
+    naive = NaiveDateTimeField(blank=True, null=True)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -14,6 +14,7 @@ from .models import (
     NaiveDateTimeTestModel,
     NaiveDateTimeAutoNowAddModel,
     NaiveDateTimeAutoNowModel,
+    NullableNaiveDateTimeModel,
 )
 
 
@@ -358,6 +359,11 @@ class NaiveDateTimeFieldTestCase(TestCase):
         ).count()
 
         self.assertTrue(find_with_naive_in_utc == 1)
+
+    def test_nullable_naive_datetimefield(self):
+        o = NullableNaiveDateTimeModel.objects.create(naive=None)
+        o.refresh_from_db()
+        self.assertIsNone(o.naive)
 
 
 def identity(v):


### PR DESCRIPTION
This was previously untested, and the bug was masked in my project because there used to be a separate path for the postgres backend in `from_db_value()` which caused the call to `is_aware` to be skipped.